### PR TITLE
Re-introduce indexing files in Synapse for use in provenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ parquet_filtered/
 parquet_final/
 session-manager-plugin.deb
 dictionaries
+archive
+manual-archive

--- a/.gitignore
+++ b/.gitignore
@@ -28,13 +28,13 @@ vignettes/*.pdf
 .Renviron
 *.Rproj
 # Misc files and dirs
-temp_aws_parquet
 *manifest*
 aws
 awscliv2.zip
-parquet_filtered/
-parquet_final/
 session-manager-plugin.deb
 dictionaries
-archive
-manual-archive
+*.parquet
+*.json
+dev*
+misc*
+*temp*

--- a/params.R
+++ b/params.R
@@ -15,6 +15,7 @@ PARQUET_FOLDER_INTERNAL <- 'syn51406699'
 
 # Local location where parquet bucket files are synced to
 AWS_PARQUET_DOWNLOAD_LOCATION <- './temp_aws_parquet'
+AWS_ARCHIVE_DOWNLOAD_LOCATION <- './temp_aws_archive'
 
 PARQUET_FILTERED_LOCATION <- './parquet_filtered'
 
@@ -26,12 +27,12 @@ datasets_to_filter <- c("dataset_enrolledparticipants",
                         "dataset_healthkitv2workouts", 
                         "dataset_symptomlog")
 
-cols_to_drop <- list(c("EmailAddress", "DateOfBirth", "CustomFields_DeviceOrderInfo", "FirstName", "LastName", "PostalCode", "MiddleName"),
+cols_to_drop <- list(c("EmailAddress", "DateOfBirth", "CustomFields_DeviceOrderInfo", "FirstName", "LastName", "PostalCode", "MiddleName", "MobilePhone"),
                      # c("name"),
                      # c("name"),
                      c("Source_Name"),
                      c("Source_Name", "Device_Name"),
-                     c("Source_Name", "Metadata_HKWorkoutBrandName", "Metadata_Coach", "Metadata_trackerMetadata", "Metadata_SWMetadataKeyCustomWorkoutTitle", "Metadata_location"),
+                     c("Source_Name", "Metadata_HKWorkoutBrandName", "Metadata_Coach", "Metadata_trackerMetadata", "Metadata_SWMetadataKeyCustomWorkoutTitle", "Metadata_location", "metadata_workout_name", "Metadata_name"),
                      c("Value_notes", "Properties"))
 
 PARQUET_FINAL_LOCATION <- './parquet_final'

--- a/sts_synindex_external.R
+++ b/sts_synindex_external.R
@@ -18,6 +18,11 @@ library(rjson)
 #'
 #' @return The path to the destination folder.
 #'
+#' @examples
+#' source_folder <- "path/to/source_folder"
+#' destination_folder <- "path/to/destination_folder"
+#' duplicate_folder(source_folder, destination_folder)
+#' 
 duplicate_folder <- function(source_folder, destination_folder) {
   if (!dir.exists(source_folder)) {
     stop("Source folder does not exist.")
@@ -42,6 +47,11 @@ duplicate_folder <- function(source_folder, destination_folder) {
 #' @param source_folder The path to the source folder.
 #' @param destination_folder The path to the destination folder.
 #'
+#' @examples
+#' source_folder <- "path/to/source_folder"
+#' destination_folder <- "path/to/destination_folder"
+#' copy_folders_reparent(source_folder, destination_folder)
+#' 
 copy_folders_reparent <- function(source_folder, destination_folder) {
   folders_to_copy <- 
     setdiff(
@@ -68,6 +78,9 @@ copy_folders_reparent <- function(source_folder, destination_folder) {
 #'
 #' @param directory_path The path of the directory to rename.
 #'
+#' @examples
+#' replace_equal_with_underscore("path_with=equals")
+#' 
 replace_equal_with_underscore <- function(directory_path) {
   new_directory_path <- gsub("=", "_", directory_path)
   if (directory_path != new_directory_path) {

--- a/sts_synindex_external.R
+++ b/sts_synindex_external.R
@@ -7,22 +7,41 @@ library(rjson)
 
 # Functions ---------------------------------------------------------------
 
+#' Duplicate a folder
+#'
+#' This function duplicates a folder from the source to the destination. It checks
+#' if the source folder exists, and if the destination folder already exists, it
+#' gives a warning about possible file overwriting.
+#'
+#' @param source_folder The path to the source folder.
+#' @param destination_folder The path to the destination folder.
+#'
+#' @return The path to the destination folder.
+#'
 duplicate_folder <- function(source_folder, destination_folder) {
-  if (dir.exists(source_folder)) {
-    if (!dir.exists(destination_folder)) {
-      dir.create(destination_folder)
-    } else {
-      warning("Destination folder already exists. Files might be overwritten.")
-    }
-    
-    system(glue::glue('cp -r {source_folder}/* {destination_folder}'))
-    return(destination_folder)
-    
-  } else {
+  if (!dir.exists(source_folder)) {
     stop("Source folder does not exist.")
   }
+  
+  if (dir.exists(destination_folder)) {
+    warning("Destination folder already exists. Files might be overwritten.")
+  } else {
+    dir.create(destination_folder)
+  }
+  
+  system(glue::glue('cp -r {source_folder}/* {destination_folder}'))
+  
+  return(destination_folder)
 }
 
+#' Copy folders and reparent
+#'
+#' This function copies folders from the source folder to the destination folder
+#' while re-parenting them. It skips folders that already exist in the destination folder.
+#'
+#' @param source_folder The path to the source folder.
+#' @param destination_folder The path to the destination folder.
+#'
 copy_folders_reparent <- function(source_folder, destination_folder) {
   folders_to_copy <- 
     setdiff(
@@ -42,11 +61,18 @@ copy_folders_reparent <- function(source_folder, destination_folder) {
   }
 }
 
+#' Replace equal sign with underscore
+#'
+#' This function renames a directory path by replacing equal signs with underscores.
+#' If a replacement is performed, it logs the change.
+#'
+#' @param directory_path The path of the directory to rename.
+#'
 replace_equal_with_underscore <- function(directory_path) {
   new_directory_path <- gsub("=", "_", directory_path)
   if (directory_path != new_directory_path) {
     file.rename(directory_path, new_directory_path)
-    cat("Renamed:", directory_path, "to", new_directory_path, "\n")
+    return(cat("Renamed:", directory_path, "to", new_directory_path, "\n"))
   }
 }
 

--- a/sts_synindex_external.R
+++ b/sts_synindex_external.R
@@ -95,13 +95,13 @@ system(sync_cmd)
 
 # Upload parquet datasets directory tree to Synapse ------------------------
 
-existing_dirs <- synGetChildren(PARQUET_FOLDER_ARCHIVE) %>% as.list()
-
-if(length(existing_dirs)>0) {
-  for (i in seq_along(existing_dirs)) {
-    synDelete(existing_dirs[[i]]$id)
-  }
-}
+# existing_dirs <- synGetChildren(PARQUET_FOLDER_ARCHIVE) %>% as.list()
+# 
+# if(length(existing_dirs)>0) {
+#   for (i in seq_along(existing_dirs)) {
+#     synDelete(existing_dirs[[i]]$id)
+#   }
+# }
 
 # Modify cohort identifier in dir name
 replace_equal_with_underscore <- function(directory_path) {
@@ -112,83 +112,13 @@ replace_equal_with_underscore <- function(directory_path) {
   }
 }
 
-invisible(lapply(list.dirs(PARQUET_FINAL_LOCATION), replace_equal_with_underscore))
-
 # Generate manifest of existing files
-sync_cmd <- glue::glue('aws s3 --profile service-catalog sync {base_s3_uri_archive} ./archive --exclude "*owner.txt*" --exclude "*archive*"')
+sync_cmd <- glue::glue('aws s3 --profile service-catalog sync {base_s3_uri_archive} {AWS_ARCHIVE_DOWNLOAD_LOCATION} --exclude "*owner.txt*" --exclude "*archive*"')
 system(sync_cmd)
 
+invisible(lapply(list.dirs(AWS_ARCHIVE_DOWNLOAD_LOCATION), replace_equal_with_underscore))
+
 SYNAPSE_AUTH_TOKEN <- Sys.getenv('SYNAPSE_AUTH_TOKEN')
-manifest_cmd <- glue::glue('SYNAPSE_AUTH_TOKEN="{SYNAPSE_AUTH_TOKEN}" synapse manifest --parent-id {PARQUET_FOLDER_ARCHIVE} --manifest ./current_manifest.tsv ./archive')
+manifest_cmd <- glue::glue('SYNAPSE_AUTH_TOKEN="{SYNAPSE_AUTH_TOKEN}" synapse manifest --parent-id {PARQUET_FOLDER_ARCHIVE} --manifest ./current_manifest.tsv {AWS_ARCHIVE_DOWNLOAD_LOCATION}')
 system(manifest_cmd)
-
-
-# # Index files in Synapse folder -------------------------------------------
-# 
-# ## Get a list of all files to upload and their synapse locations(parentId) 
-# STR_LEN_PARQUET_FINAL_LOCATION <- stringr::str_length(PARQUET_FINAL_LOCATION)
-# 
-# ## All files present locally from manifest
-# synapse_manifest <- read.csv('./current_manifest.tsv', sep = '\t', stringsAsFactors = F) %>% 
-#   dplyr::filter(path != paste0(PARQUET_FINAL_LOCATION,'/owner.txt')) %>%  # need not create a dataFileHandleId for owner.txt
-#   dplyr::rowwise() %>% 
-#   dplyr::mutate(file_key = stringr::str_sub(string = path, start = STR_LEN_PARQUET_FINAL_LOCATION+2)) %>% # location of file from home folder of S3 bucket
-#   dplyr::mutate(s3_file_key = paste0('main/parquet/', file_key)) %>% # the namespace for files in the S3 bucket is S3::bucket/main/
-#   dplyr::mutate(md5_hash = as.character(tools::md5sum(path))) %>% 
-#   dplyr::ungroup()
-# 
-# ## All currently indexed files in Synapse
-# synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% read.csv()
-# synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% read.csv()
-# 
-# ## find those files that are not in the fileview - files that need to be indexed
-# if (nrow(synapse_fileview)>0) {
-#   synapse_manifest_to_upload <- 
-#     synapse_manifest %>% 
-#     dplyr::anti_join(
-#       synapse_fileview %>% 
-#         dplyr::select(parent = parentId,
-#                       s3_file_key = dataFileKey,
-#                       md5_hash = dataFileMD5Hex))
-#   synapse_manifest_to_upload <- 
-#     synapse_manifest_to_upload %>% 
-#     mutate(file_key = gsub("cohort_", "cohort=", file_key),
-#            s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
-# } else {
-#   synapse_manifest_to_upload <- 
-#     synapse_manifest %>% 
-#     mutate(file_key = gsub("cohort_", "cohort=", file_key),
-#            s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
-# }
-# 
-# ## For each file index it in Synapse given a parent synapse folder
-# if(nrow(synapse_manifest_to_upload) > 0){ # there are some files to upload
-#   for(file_number in seq(nrow(synapse_manifest_to_upload))){
-#     
-#     # file and related synapse parent id 
-#     file_= synapse_manifest_to_upload$path[file_number]
-#     parent_id = synapse_manifest_to_upload$parent[file_number]
-#     s3_file_key = synapse_manifest_to_upload$s3_file_key[file_number]
-#     # this would be the location of the file in the S3 bucket, in the local it is at {AWS_PARQUET_DOWNLOAD_LOCATION}/
-#     
-#     absolute_file_path <- tools::file_path_as_absolute(file_) # local absolute path
-#     
-#     temp_syn_obj <- synapser::synCreateExternalS3FileHandle(
-#       bucket_name = PARQUET_BUCKET_EXTERNAL,
-#       s3_file_key = s3_file_key, #
-#       file_path = absolute_file_path,
-#       parent = parent_id
-#     )
-#     
-#     # synapse does not accept ':' (colon) in filenames, so replacing it with '_colon_'
-#     new_fileName <- stringr::str_replace_all(temp_syn_obj$fileName, ':', '_colon_')
-#     
-#     f <- File(dataFileHandleId=temp_syn_obj$id,
-#               parentId=parent_id,
-#               name = new_fileName) ## set the new file name
-#     
-#     f <- synStore(f)
-#     
-#   }
-# }
 

--- a/sts_synindex_external.R
+++ b/sts_synindex_external.R
@@ -210,26 +210,25 @@ synapse_manifest_to_upload <-
 
 # Index each file in Synapse
 if(nrow(synapse_manifest_to_upload) > 0){
-  for(file_number in seq(nrow(synapse_manifest_to_upload))){
-    file_ <- synapse_manifest_to_upload$path[file_number]
-    parent_id <- synapse_manifest_to_upload$parent[file_number]
-    s3_file_key <- synapse_manifest_to_upload$s3_file_key[file_number]
-    absolute_file_path <- tools::file_path_as_absolute(file_)
+  for(file_number in seq_len(nrow(synapse_manifest_to_upload))){
+    tmp <- synapse_manifest_to_upload[file_number, c("path", "parent", "s3_file_key")]
+    
+    absolute_file_path <- tools::file_path_as_absolute(tmp$path)
 
     temp_syn_obj <- 
       synapser::synCreateExternalS3FileHandle(
         bucket_name = PARQUET_BUCKET_EXTERNAL,
-        s3_file_key = s3_file_key,
+        s3_file_key = tmp$s3_file_key,
         file_path = absolute_file_path,
-        parent = parent_id)
+        parent = tmp$parent)
 
     new_fileName <- stringr::str_replace_all(temp_syn_obj$fileName, ':', '_colon_')
 
-    f <- File(dataFileHandleId=temp_syn_obj$id,
-              parentId=parent_id,
-              name = new_fileName)
-
-    f <- synStore(f)
+    f <- 
+      synStore(
+        File(dataFileHandleId = temp_syn_obj$id,
+             parentId = tmp$parent,
+             name = new_fileName))
 
   }
 }

--- a/sts_synindex_external.R
+++ b/sts_synindex_external.R
@@ -59,8 +59,8 @@ copy_folders_reparent <- function(source_folder, destination_folder) {
       list.dirs(destination_folder, recursive = F, full.names = F))
   
   for (folder in folders_to_copy) {
-    source_path <- paste0(AWS_PARQUET_DOWNLOAD_LOCATION, '/', folder)
-    dest_path <- paste0(PARQUET_FINAL_LOCATION, '/', folder)
+    source_path <- paste0(source_folder, '/', folder)
+    dest_path <- paste0(destination_folder, '/', folder)
     
     if (!dir.exists(dest_path)) {
       system(glue::glue('cp -r {source_path} {destination_folder}'))

--- a/sts_synindex_external.R
+++ b/sts_synindex_external.R
@@ -199,16 +199,14 @@ if (nrow(synapse_fileview)>0) {
         dplyr::select(parent = parentId,
                       s3_file_key = dataFileKey,
                       md5_hash = dataFileMD5Hex))
-  synapse_manifest_to_upload <-
-    synapse_manifest_to_upload %>%
-    mutate(file_key = gsub("cohort_", "cohort=", file_key),
-           s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
 } else {
-  synapse_manifest_to_upload <-
-    synapse_manifest %>%
-    mutate(file_key = gsub("cohort_", "cohort=", file_key),
-           s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
+  synapse_manifest_to_upload <- synapse_manifest
 }
+
+synapse_manifest_to_upload <-
+  synapse_manifest_to_upload %>%
+  mutate(file_key = gsub("cohort_", "cohort=", file_key),
+         s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
 
 # Index each file in Synapse
 if(nrow(synapse_manifest_to_upload) > 0){

--- a/sts_synindex_external.R
+++ b/sts_synindex_external.R
@@ -148,7 +148,7 @@ sync_cmd <- glue::glue('aws s3 --profile service-catalog sync {base_s3_uri_archi
 system(sync_cmd)
 
 # Modify cohort identifier in dir name
-invisible(lapply(list.dirs(AWS_ARCHIVE_DOWNLOAD_LOCATION), replace_equal_with_underscore))
+junk <- sapply(list.dirs(AWS_ARCHIVE_DOWNLOAD_LOCATION), replace_equal_with_underscore)
 
 SYNAPSE_AUTH_TOKEN <- Sys.getenv('SYNAPSE_AUTH_TOKEN')
 manifest_cmd <- glue::glue('SYNAPSE_AUTH_TOKEN="{SYNAPSE_AUTH_TOKEN}" synapse manifest --parent-id {PARQUET_FOLDER_ARCHIVE} --manifest ./current_manifest.tsv {AWS_ARCHIVE_DOWNLOAD_LOCATION}')

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(recover-parquet-external)
+
+test_check("recover-parquet-external")

--- a/tests/testthat/test-sts_synindex_external.R
+++ b/tests/testthat/test-sts_synindex_external.R
@@ -1,0 +1,58 @@
+library(testthat)
+
+# Test for duplicate_folder
+test_that("duplicate_folder correctly duplicates a folder", {
+  td <- "tmpdir"
+  dir.create(td)
+  source_folder <- file.path(td, "source_folder")
+  destination_folder <- file.path(td, "destination_folder")
+  dir.create(source_folder)
+  file.create(file.path(source_folder, "file1.txt"))
+  
+  # Create a separate temporary directory for the destination
+  expect_true(dir.exists(source_folder))
+  result <- duplicate_folder(source_folder, destination_folder)
+  
+  expect_true(file.exists(file.path(destination_folder, "file1.txt")))
+  expect_equal(result, destination_folder)
+  
+  # Use expect_message to capture the warning
+  # expect_message(result, "Destination folder already exists. Files might be overwritten.")
+  
+  # Clean up the temporary directories
+  unlink(td, recursive = T)
+})
+
+# Test for copy_folders_reparent
+test_that("copy_folders_reparent correctly copies folders", {
+  td <- "tmpdir"
+  dir.create(td)
+  source_folder <- file.path(td, "source_folder")
+  destination_folder <- file.path(td, "destination_folder")
+  dir.create(source_folder)
+  dir.create(destination_folder)
+  dir.create(file.path(source_folder, "folder1"))
+  file.create(file.path(source_folder, "folder1", "folder1.txt"))
+  dir.create(file.path(source_folder, "folder2"))
+  file.create(file.path(source_folder, "folder2", "folder2.txt"))
+  result <- copy_folders_reparent(source_folder, destination_folder)
+  expect_true(dir.exists(file.path(destination_folder, "folder1")))
+  expect_true(dir.exists(file.path(destination_folder, "folder2")))
+  expect_true(file.exists(file.path(destination_folder, "folder1", "folder1.txt")))
+  expect_true(file.exists(file.path(destination_folder, "folder2", "folder2.txt")))
+  # expect_output(result, "Copied.*")
+  unlink(td, recursive = T)
+})
+
+# Test for replace_equal_with_underscore
+test_that("replace_equal_with_underscore correctly replaces equal sign with underscore", {
+  td <- "tmpdir"
+  dir.create(td)
+  original_path <- "path=with=equals"
+  dir.create(file.path(td, original_path))
+  replace_equal_with_underscore(file.path(td, original_path))
+  expect_equal(list.dirs(td, recursive = F, full.names = F), "path_with_equals")
+  expect_true(dir.exists(list.dirs(td, recursive = F, full.names = T)))
+  # expect_output(new_path, "Renamed.*")
+  unlink(td, recursive = T)
+})


### PR DESCRIPTION
## Major Changes

1. Reintroduce indexing of files in Synapse via creating file handles linked to S3 objects
2. Update list of columns to drop
3. Add documentation for functions
4. Add unit tests

## Minor Changes

1. Clean and organize code
2. Update gitignore
3. General optimizations (remove redundancies, reduce size, etc.)
