### PR TITLE
Add new workflow to move validated data from a staging location to an archive location

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -21,6 +21,7 @@ prod:
   SYNAPSE_FILEVIEW_ID: syn52504776
   PII_COLS_TO_DROP: syn52523394
   DEID_VALS_TO_REVIEW: syn52409518
+  STAGING_TO_ARCHIVE_DOWNLOAD_LOCATION: ./temp_staging_to_archive/
 
 staging:
   inherits: prod

--- a/staging_to_archive.R
+++ b/staging_to_archive.R
@@ -1,13 +1,22 @@
 library(synapser)
+library(tidyverse)
 
 synapser::synLogin(authToken = Sys.getenv('SYNAPSE_AUTH_TOKEN'))
 
-base_s3_uri_staging <- paste0('s3://', PARQUET_BUCKET_EXTERNAL, '/', PARQUET_BUCKET_BASE_KEY_ARCHIVE)
+base_s3_uri_staging <- 
+  paste0('s3://', 
+         config::get("PARQUET_BUCKET_EXTERNAL", "staging"), 
+         '/', 
+         config::get("PARQUET_BUCKET_BASE_KEY_ARCHIVE", "staging"))
 
 rm(list = names(config::get(config = "staging")))
 config::get(config = "prod") %>% list2env(envir = .GlobalEnv)
 
-base_s3_uri_archive <- paste0('s3://', PARQUET_BUCKET_EXTERNAL, '/', PARQUET_BUCKET_BASE_KEY_ARCHIVE)
+base_s3_uri_archive <- 
+  paste0('s3://', 
+         PARQUET_BUCKET_EXTERNAL, 
+         '/', 
+         PARQUET_BUCKET_BASE_KEY_ARCHIVE)
 
 validated_date <- readline("Enter name of validated staging folder in yyyy-mm-dd format: ")
 cmd <- glue::glue("aws s3 --profile service-catalog cp {base_s3_uri_staging}{validated_date} {base_s3_uri_archive} --exclude '*owner.txt*' --exclude '*archive*'")

--- a/staging_to_archive.R
+++ b/staging_to_archive.R
@@ -1,0 +1,6 @@
+rm(list = names(config::get(config = "staging")))
+config::get(config = "prod") %>% list2env(envir = .GlobalEnv)
+
+validated_date <- readline("Enter name of validated staging folder in yyyy-mm-dd format: ")
+cmd <- glue::glue("aws s3 --profile service-catalog cp {base_s3_uri_staging}/{validated_date} {base_s3_uri_archive}")
+rm(validated_date)

--- a/staging_to_archive.R
+++ b/staging_to_archive.R
@@ -1,6 +1,11 @@
+base_s3_uri_staging <- paste0('s3://', PARQUET_BUCKET_EXTERNAL, '/', PARQUET_BUCKET_BASE_KEY_ARCHIVE)
+
 rm(list = names(config::get(config = "staging")))
 config::get(config = "prod") %>% list2env(envir = .GlobalEnv)
 
+base_s3_uri_archive <- paste0('s3://', PARQUET_BUCKET_EXTERNAL, '/', PARQUET_BUCKET_BASE_KEY_ARCHIVE)
+
 validated_date <- readline("Enter name of validated staging folder in yyyy-mm-dd format: ")
-cmd <- glue::glue("aws s3 --profile service-catalog cp {base_s3_uri_staging}/{validated_date} {base_s3_uri_archive}")
+cmd <- glue::glue("aws s3 --profile service-catalog cp {base_s3_uri_staging}{validated_date} {base_s3_uri_archive}")
 rm(validated_date)
+

--- a/staging_to_archive.R
+++ b/staging_to_archive.R
@@ -21,11 +21,16 @@ base_s3_uri_archive <-
 validated_date <- readline("Enter name of validated staging folder in yyyy-mm-dd format: ")
 
 if (!is.null(synFindEntityId(validated_date, config::get("PARQUET_FOLDER_ARCHIVE", "staging")))) {
-  cmd <- glue::glue("aws s3 --profile service-catalog cp {base_s3_uri_staging}{validated_date} {base_s3_uri_archive} --exclude '*owner.txt*' --exclude '*archive*'")
-  rm(validated_date)
+  sync_cmd <- glue::glue("aws s3 --profile service-catalog sync {base_s3_uri_staging}{validated_date}/ {STAGING_TO_ARCHIVE_DOWNLOAD_LOCATION} --exclude '*owner.txt*' --exclude '*archive*'")
+  system(sync_cmd)
+  rm(sync_cmd)
+  sync_cmd <- glue::glue("aws s3 --profile service-catalog sync {STAGING_TO_ARCHIVE_DOWNLOAD_LOCATION} {base_s3_uri_archive}{validated_date}/ --exclude '*owner.txt*' --exclude '*archive*'")
+  system(sync_cmd)
+  
+  rm(sync_cmd, validated_date)
   
   # Sync entire bucket to local
-  unlink(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = T, force = T)
+  unlink(STAGING_TO_ARCHIVE_DOWNLOAD_LOCATION, recursive = T, force = T)
   unlink(AWS_ARCHIVE_DOWNLOAD_LOCATION, recursive = T, force = T)
   sync_cmd <- glue::glue('aws s3 --profile service-catalog sync {base_s3_uri_archive} {AWS_ARCHIVE_DOWNLOAD_LOCATION} --exclude "*owner.txt*" --exclude "*archive*"')
   system(sync_cmd)

--- a/staging_to_archive.R
+++ b/staging_to_archive.R
@@ -19,90 +19,93 @@ base_s3_uri_archive <-
          PARQUET_BUCKET_BASE_KEY_ARCHIVE)
 
 validated_date <- readline("Enter name of validated staging folder in yyyy-mm-dd format: ")
-cmd <- glue::glue("aws s3 --profile service-catalog cp {base_s3_uri_staging}{validated_date} {base_s3_uri_archive} --exclude '*owner.txt*' --exclude '*archive*'")
-rm(validated_date)
 
-# Sync entire bucket to local
-unlink(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = T, force = T)
-unlink(AWS_ARCHIVE_DOWNLOAD_LOCATION, recursive = T, force = T)
-sync_cmd <- glue::glue('aws s3 --profile service-catalog sync {base_s3_uri_archive} {AWS_ARCHIVE_DOWNLOAD_LOCATION} --exclude "*owner.txt*" --exclude "*archive*"')
-system(sync_cmd)
-
-# Modify cohort identifier in dir name
-junk <- sapply(list.dirs(AWS_ARCHIVE_DOWNLOAD_LOCATION), replace_equal_with_underscore)
-
-# Generate manifest of existing files
-SYNAPSE_AUTH_TOKEN <- Sys.getenv('SYNAPSE_AUTH_TOKEN')
-manifest_cmd <- glue::glue('SYNAPSE_AUTH_TOKEN="{SYNAPSE_AUTH_TOKEN}" synapse manifest --parent-id {PARQUET_FOLDER_ARCHIVE} --manifest ./current_manifest.tsv {AWS_ARCHIVE_DOWNLOAD_LOCATION}')
-system(manifest_cmd)
-
-
-# Index files in Synapse --------------------------------------------------
-# Get a list of all files to upload and their synapse locations (parentId)
-STR_LEN_PARQUET_FINAL_LOCATION <- stringr::str_length(AWS_ARCHIVE_DOWNLOAD_LOCATION)
-
-## List all local files present (from manifest)
-synapse_manifest <- 
-  read.csv('./current_manifest.tsv', sep = '\t', stringsAsFactors = F) %>%
-  dplyr::filter(!grepl('owner.txt', path)) %>%
-  dplyr::rowwise() %>%
-  dplyr::mutate(file_key = stringr::str_sub(string = path, start = STR_LEN_PARQUET_FINAL_LOCATION+2)) %>%
-  dplyr::mutate(s3_file_key = paste0(PARQUET_BUCKET_BASE_KEY_ARCHIVE, file_key)) %>%
-  dplyr::mutate(md5_hash = as.character(tools::md5sum(path))) %>%
-  dplyr::ungroup() %>% 
-  dplyr::mutate(file_key = gsub("cohort_", "cohort=", file_key),
-                s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
-
-
-# List all files currently indexed in Synapse
-synapse_fileview <- 
-  synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>%
-  read.csv()
-synapse_fileview <- 
-  synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% 
-  read.csv()
-
-# Find the files in the manifest that are not yet indexed in Synapse
-if (nrow(synapse_fileview)>0) {
-  synapse_manifest_to_upload <-
-    synapse_manifest %>%
-    dplyr::anti_join(
-      synapse_fileview %>%
-        dplyr::select(parent = parentId,
-                      s3_file_key = dataFileKey,
-                      md5_hash = dataFileMD5Hex))
-} else {
-  synapse_manifest_to_upload <- synapse_manifest
-}
-
-# Index each file in Synapse
-latest_commit <- gh::gh("/repos/:owner/:repo/commits/main", owner = "Sage-Bionetworks", repo = "recover-parquet-external")
-latest_commit_tree_url <- latest_commit$html_url %>% stringr::str_replace("commit", "tree")
-
-if(nrow(synapse_manifest_to_upload) > 0){
-  for(file_number in seq_len(nrow(synapse_manifest_to_upload))){
-    tmp <- synapse_manifest_to_upload[file_number, c("path", "parent", "s3_file_key")]
-    
-    absolute_file_path <- tools::file_path_as_absolute(tmp$path)
-    
-    temp_syn_obj <- 
-      synapser::synCreateExternalS3FileHandle(
-        bucket_name = PARQUET_BUCKET_EXTERNAL,
-        s3_file_key = tmp$s3_file_key,
-        file_path = absolute_file_path,
-        parent = tmp$parent)
-    
-    new_fileName <- stringr::str_replace_all(temp_syn_obj$fileName, ':', '_colon_')
-    
-    f <- File(dataFileHandleId = temp_syn_obj$id,
-              parentId = tmp$parent,
-              name = new_fileName)
-    
-    f <- synStore(f, 
-                  activityName = "Indexing", 
-                  activityDescription = "Indexing external parquet datasets",
-                  used = PARQUET_FOLDER_INTERNAL, 
-                  executed = latest_commit_tree_url)
-    
+if (!is.null(synFindEntityId(validated_date, config::get("PARQUET_FOLDER_ARCHIVE", "staging")))) {
+  cmd <- glue::glue("aws s3 --profile service-catalog cp {base_s3_uri_staging}{validated_date} {base_s3_uri_archive} --exclude '*owner.txt*' --exclude '*archive*'")
+  rm(validated_date)
+  
+  # Sync entire bucket to local
+  unlink(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = T, force = T)
+  unlink(AWS_ARCHIVE_DOWNLOAD_LOCATION, recursive = T, force = T)
+  sync_cmd <- glue::glue('aws s3 --profile service-catalog sync {base_s3_uri_archive} {AWS_ARCHIVE_DOWNLOAD_LOCATION} --exclude "*owner.txt*" --exclude "*archive*"')
+  system(sync_cmd)
+  
+  # Modify cohort identifier in dir name
+  junk <- sapply(list.dirs(AWS_ARCHIVE_DOWNLOAD_LOCATION), replace_equal_with_underscore)
+  
+  # Generate manifest of existing files
+  SYNAPSE_AUTH_TOKEN <- Sys.getenv('SYNAPSE_AUTH_TOKEN')
+  manifest_cmd <- glue::glue('SYNAPSE_AUTH_TOKEN="{SYNAPSE_AUTH_TOKEN}" synapse manifest --parent-id {PARQUET_FOLDER_ARCHIVE} --manifest ./current_manifest.tsv {AWS_ARCHIVE_DOWNLOAD_LOCATION}')
+  system(manifest_cmd)
+  
+  
+  # Index files in Synapse --------------------------------------------------
+  # Get a list of all files to upload and their synapse locations (parentId)
+  STR_LEN_PARQUET_FINAL_LOCATION <- stringr::str_length(AWS_ARCHIVE_DOWNLOAD_LOCATION)
+  
+  ## List all local files present (from manifest)
+  synapse_manifest <- 
+    read.csv('./current_manifest.tsv', sep = '\t', stringsAsFactors = F) %>%
+    dplyr::filter(!grepl('owner.txt', path)) %>%
+    dplyr::rowwise() %>%
+    dplyr::mutate(file_key = stringr::str_sub(string = path, start = STR_LEN_PARQUET_FINAL_LOCATION+2)) %>%
+    dplyr::mutate(s3_file_key = paste0(PARQUET_BUCKET_BASE_KEY_ARCHIVE, file_key)) %>%
+    dplyr::mutate(md5_hash = as.character(tools::md5sum(path))) %>%
+    dplyr::ungroup() %>% 
+    dplyr::mutate(file_key = gsub("cohort_", "cohort=", file_key),
+                  s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
+  
+  
+  # List all files currently indexed in Synapse
+  synapse_fileview <- 
+    synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>%
+    read.csv()
+  synapse_fileview <- 
+    synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% 
+    read.csv()
+  
+  # Find the files in the manifest that are not yet indexed in Synapse
+  if (nrow(synapse_fileview)>0) {
+    synapse_manifest_to_upload <-
+      synapse_manifest %>%
+      dplyr::anti_join(
+        synapse_fileview %>%
+          dplyr::select(parent = parentId,
+                        s3_file_key = dataFileKey,
+                        md5_hash = dataFileMD5Hex))
+  } else {
+    synapse_manifest_to_upload <- synapse_manifest
+  }
+  
+  # Index each file in Synapse
+  latest_commit <- gh::gh("/repos/:owner/:repo/commits/main", owner = "Sage-Bionetworks", repo = "recover-parquet-external")
+  latest_commit_tree_url <- latest_commit$html_url %>% stringr::str_replace("commit", "tree")
+  
+  if(nrow(synapse_manifest_to_upload) > 0){
+    for(file_number in seq_len(nrow(synapse_manifest_to_upload))){
+      tmp <- synapse_manifest_to_upload[file_number, c("path", "parent", "s3_file_key")]
+      
+      absolute_file_path <- tools::file_path_as_absolute(tmp$path)
+      
+      temp_syn_obj <- 
+        synapser::synCreateExternalS3FileHandle(
+          bucket_name = PARQUET_BUCKET_EXTERNAL,
+          s3_file_key = tmp$s3_file_key,
+          file_path = absolute_file_path,
+          parent = tmp$parent)
+      
+      new_fileName <- stringr::str_replace_all(temp_syn_obj$fileName, ':', '_colon_')
+      
+      f <- File(dataFileHandleId = temp_syn_obj$id,
+                parentId = tmp$parent,
+                name = new_fileName)
+      
+      f <- synStore(f, 
+                    activityName = "Indexing", 
+                    activityDescription = "Indexing external parquet datasets",
+                    used = PARQUET_FOLDER_INTERNAL, 
+                    executed = latest_commit_tree_url)
+      
+    }
   }
 }

--- a/staging_to_archive.R
+++ b/staging_to_archive.R
@@ -1,3 +1,7 @@
+library(synapser)
+
+synapser::synLogin(authToken = Sys.getenv('SYNAPSE_AUTH_TOKEN'))
+
 base_s3_uri_staging <- paste0('s3://', PARQUET_BUCKET_EXTERNAL, '/', PARQUET_BUCKET_BASE_KEY_ARCHIVE)
 
 rm(list = names(config::get(config = "staging")))
@@ -6,6 +10,90 @@ config::get(config = "prod") %>% list2env(envir = .GlobalEnv)
 base_s3_uri_archive <- paste0('s3://', PARQUET_BUCKET_EXTERNAL, '/', PARQUET_BUCKET_BASE_KEY_ARCHIVE)
 
 validated_date <- readline("Enter name of validated staging folder in yyyy-mm-dd format: ")
-cmd <- glue::glue("aws s3 --profile service-catalog cp {base_s3_uri_staging}{validated_date} {base_s3_uri_archive}")
+cmd <- glue::glue("aws s3 --profile service-catalog cp {base_s3_uri_staging}{validated_date} {base_s3_uri_archive} --exclude '*owner.txt*' --exclude '*archive*'")
 rm(validated_date)
 
+# Sync entire bucket to local
+unlink(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = T, force = T)
+unlink(AWS_ARCHIVE_DOWNLOAD_LOCATION, recursive = T, force = T)
+sync_cmd <- glue::glue('aws s3 --profile service-catalog sync {base_s3_uri_archive} {AWS_ARCHIVE_DOWNLOAD_LOCATION} --exclude "*owner.txt*" --exclude "*archive*"')
+system(sync_cmd)
+
+# Modify cohort identifier in dir name
+junk <- sapply(list.dirs(AWS_ARCHIVE_DOWNLOAD_LOCATION), replace_equal_with_underscore)
+
+# Generate manifest of existing files
+SYNAPSE_AUTH_TOKEN <- Sys.getenv('SYNAPSE_AUTH_TOKEN')
+manifest_cmd <- glue::glue('SYNAPSE_AUTH_TOKEN="{SYNAPSE_AUTH_TOKEN}" synapse manifest --parent-id {PARQUET_FOLDER_ARCHIVE} --manifest ./current_manifest.tsv {AWS_ARCHIVE_DOWNLOAD_LOCATION}')
+system(manifest_cmd)
+
+
+# Index files in Synapse --------------------------------------------------
+# Get a list of all files to upload and their synapse locations (parentId)
+STR_LEN_PARQUET_FINAL_LOCATION <- stringr::str_length(AWS_ARCHIVE_DOWNLOAD_LOCATION)
+
+## List all local files present (from manifest)
+synapse_manifest <- 
+  read.csv('./current_manifest.tsv', sep = '\t', stringsAsFactors = F) %>%
+  dplyr::filter(!grepl('owner.txt', path)) %>%
+  dplyr::rowwise() %>%
+  dplyr::mutate(file_key = stringr::str_sub(string = path, start = STR_LEN_PARQUET_FINAL_LOCATION+2)) %>%
+  dplyr::mutate(s3_file_key = paste0(PARQUET_BUCKET_BASE_KEY_ARCHIVE, file_key)) %>%
+  dplyr::mutate(md5_hash = as.character(tools::md5sum(path))) %>%
+  dplyr::ungroup() %>% 
+  dplyr::mutate(file_key = gsub("cohort_", "cohort=", file_key),
+                s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
+
+
+# List all files currently indexed in Synapse
+synapse_fileview <- 
+  synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>%
+  read.csv()
+synapse_fileview <- 
+  synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% 
+  read.csv()
+
+# Find the files in the manifest that are not yet indexed in Synapse
+if (nrow(synapse_fileview)>0) {
+  synapse_manifest_to_upload <-
+    synapse_manifest %>%
+    dplyr::anti_join(
+      synapse_fileview %>%
+        dplyr::select(parent = parentId,
+                      s3_file_key = dataFileKey,
+                      md5_hash = dataFileMD5Hex))
+} else {
+  synapse_manifest_to_upload <- synapse_manifest
+}
+
+# Index each file in Synapse
+latest_commit <- gh::gh("/repos/:owner/:repo/commits/main", owner = "Sage-Bionetworks", repo = "recover-parquet-external")
+latest_commit_tree_url <- latest_commit$html_url %>% stringr::str_replace("commit", "tree")
+
+if(nrow(synapse_manifest_to_upload) > 0){
+  for(file_number in seq_len(nrow(synapse_manifest_to_upload))){
+    tmp <- synapse_manifest_to_upload[file_number, c("path", "parent", "s3_file_key")]
+    
+    absolute_file_path <- tools::file_path_as_absolute(tmp$path)
+    
+    temp_syn_obj <- 
+      synapser::synCreateExternalS3FileHandle(
+        bucket_name = PARQUET_BUCKET_EXTERNAL,
+        s3_file_key = tmp$s3_file_key,
+        file_path = absolute_file_path,
+        parent = tmp$parent)
+    
+    new_fileName <- stringr::str_replace_all(temp_syn_obj$fileName, ':', '_colon_')
+    
+    f <- File(dataFileHandleId = temp_syn_obj$id,
+              parentId = tmp$parent,
+              name = new_fileName)
+    
+    f <- synStore(f, 
+                  activityName = "Indexing", 
+                  activityDescription = "Indexing external parquet datasets",
+                  used = PARQUET_FOLDER_INTERNAL, 
+                  executed = latest_commit_tree_url)
+    
+  }
+}

--- a/sts_synindex_external.R
+++ b/sts_synindex_external.R
@@ -92,7 +92,6 @@ replace_equal_with_underscore <- function(directory_path) {
 # Setup -------------------------------------------------------------------
 synapser::synLogin(authToken = Sys.getenv('SYNAPSE_AUTH_TOKEN'))
 config::get(config = "staging") %>% list2env(envir = .GlobalEnv)
-# config::get(config = "prod") %>% list2env(envir = .GlobalEnv)
 
 
 # Get STS credentials for input data bucket -------------------------------
@@ -145,16 +144,6 @@ source('~/recover-parquet-external/deidentification.R')
 date <- lubridate::today()
 sync_cmd <- glue::glue('aws s3 --profile service-catalog sync {PARQUET_FINAL_LOCATION} {base_s3_uri_archive}{date}/ --exclude "*owner.txt*" --exclude "*archive*"')
 system(sync_cmd)
-
-
-# Recreate directory tree of parquet datasets bucket location in S --------
-# existing_dirs <- synGetChildren(PARQUET_FOLDER_ARCHIVE) %>% as.list()
-# 
-# if(length(existing_dirs)>0) {
-#   for (i in seq_along(existing_dirs)) {
-#     synDelete(existing_dirs[[i]]$id)
-#   }
-# }
 
 # Sync entire bucket to local
 unlink(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = T, force = T)


### PR DESCRIPTION
## Major Changes

1. New script for workflow to sync selected validated data from s3 location to archive s3 location and then index in synapse

## Minor Changes

1. Create new prod param to indicate path to use for syncing to/from for staging to archive ops
2. Remove unused, commented code
3. Borrow necessary function from other file in new file