### PR TITLE
RMHDR-228 Remove withdrawn participants' data

### DIFF
--- a/filtering.R
+++ b/filtering.R
@@ -83,15 +83,18 @@ tmp <-
                        partitions = "cohort")
     })
 
-# TODO: Replace tested code below with real variables and pointers once pilot data is available
-# participants_to_withdraw <- tmpf$ParticipantIdentifier[wdp$EOPRemoveData==1]
-participants_to_withdraw <- c("RA11101-00754", "RA11303-00148", "RA12301-00099")
+participants_to_withdraw <- 
+  arrow::open_dataset(paste0(PARQUET_FILTERED_LOCATION, "/dataset_enrolledparticipants/")) %>% 
+  dplyr::select(ParticipantIdentifier, CustomFields_EOPRemoveData) %>% 
+  dplyr::filter(CustomFields_EOPRemoveData==1) %>%
+  dplyr::pull(ParticipantIdentifier, as_vector = TRUE) %>% 
+  unique()
 
-lapply(list.dirs("./test_dir", recursive = F), function(x) {
+lapply(list.dirs(PARQUET_FILTERED_LOCATION, recursive = F), function(x) {
   d <- 
     arrow::open_dataset(x) %>% 
     filter(!ParticipantIdentifier %in% participants_to_withdraw) %>% 
-    arrow::write_dataset(path = gsub("./test_dir/", "./test_dir_new/", x), 
+    arrow::write_dataset(path = x, 
                          max_rows_per_file = 100000,
                          partitioning = "cohort", 
                          existing_data_behavior = 'delete_matching',

--- a/filtering.R
+++ b/filtering.R
@@ -83,3 +83,25 @@ tmp <-
                        partitions = "cohort")
     })
 
+# TODO: Replace tested code below with real variables and pointers once pilot data is available
+# participants_to_withdraw <- tmpf$ParticipantIdentifier[wdp$EOPRemoveData==1]
+participants_to_withdraw <- c("RA11101-00754", "RA11303-00148", "RA12301-00099")
+
+lapply(list.dirs("./test_dir", recursive = F), function(x) {
+  d <- 
+    arrow::open_dataset(x) %>% 
+    filter(!ParticipantIdentifier %in% participants_to_withdraw) %>% 
+    arrow::write_dataset(path = gsub("./test_dir/", "./test_dir_new/", x), 
+                         max_rows_per_file = 100000,
+                         partitioning = "cohort", 
+                         existing_data_behavior = 'delete_matching',
+                         basename_template = paste0("part-0000{i}.", as.character("parquet")))
+})
+
+lapply(list.dirs("test_dir", recursive = F), function(x) {
+  grepl("RA12301-00099", (open_dataset(x) %>% select(ParticipantIdentifier) %>% collect() %>% as.list()))
+})
+
+lapply(list.dirs("test_dir_new", recursive = F), function(x) {
+  grepl("RA12301-00099", (open_dataset(x) %>% select(ParticipantIdentifier) %>% collect() %>% as.list()))
+})

--- a/filtering.R
+++ b/filtering.R
@@ -82,29 +82,3 @@ tmp <-
                        output = PARQUET_FILTERED_LOCATION, 
                        partitions = "cohort")
     })
-
-participants_to_withdraw <- 
-  arrow::open_dataset(paste0(PARQUET_FILTERED_LOCATION, "/dataset_enrolledparticipants/")) %>% 
-  dplyr::select(ParticipantIdentifier, CustomFields_EOPRemoveData) %>% 
-  dplyr::filter(CustomFields_EOPRemoveData==1) %>%
-  dplyr::pull(ParticipantIdentifier, as_vector = TRUE) %>% 
-  unique()
-
-lapply(list.dirs(PARQUET_FILTERED_LOCATION, recursive = F), function(x) {
-  d <- 
-    arrow::open_dataset(x) %>% 
-    filter(!ParticipantIdentifier %in% participants_to_withdraw) %>% 
-    arrow::write_dataset(path = x, 
-                         max_rows_per_file = 100000,
-                         partitioning = "cohort", 
-                         existing_data_behavior = 'delete_matching',
-                         basename_template = paste0("part-0000{i}.", as.character("parquet")))
-})
-
-lapply(list.dirs("test_dir", recursive = F), function(x) {
-  grepl("RA12301-00099", (open_dataset(x) %>% select(ParticipantIdentifier) %>% collect() %>% as.list()))
-})
-
-lapply(list.dirs("test_dir_new", recursive = F), function(x) {
-  grepl("RA12301-00099", (open_dataset(x) %>% select(ParticipantIdentifier) %>% collect() %>% as.list()))
-})

--- a/remove_withdrawn_participants.R
+++ b/remove_withdrawn_participants.R
@@ -47,12 +47,6 @@ contains_pid_false <-
   dplyr::filter(value==FALSE) %>% 
   dplyr::pull(name)
 
-# fitbitsleeplogs -> fitbitsleeplogs_sleeplogdetails: match on LogId
-# symptomlog -> symptomlog_value_symptoms, symptomlog_value_treatments: match on DataPointKey
-# healthkitv2electrocardiogram -> healthkitv2electrocardiogram_subsamples: match on HealthKitECGSampleKey
-# healthkitv2heartbeat -> healthkitv2heartbeat_subsamples: match on HealthKitHeartbeatSampleKey
-# healthkitv2workouts -> healthkitv2workouts_events: match on HealthKitWorkoutKey
-
 fitbitsleeplogs_sleeplogdetails_to_withdraw <-
   get_mappingID_vals_to_withdraw("dataset_fitbitsleeplogs", "LogId")
 

--- a/remove_withdrawn_participants.R
+++ b/remove_withdrawn_participants.R
@@ -6,7 +6,12 @@
 #' This function gets the values of an identifier variable in 
 #' datasets that do not contain the ParticipantIdentifier variable, but 
 #' only for the corresponding ParticipantIdentifer values that are found 
-#' in a list containing ParticipantIdentifier values of withdrawn participants.
+#' in a list containing ParticipantIdentifier values of withdrawn participants. 
+#' For example, if dataset A contains ParticipantIdentifier and DataKey columns, 
+#' and dataset B contains the DataKey column but not the ParticipantIdentifier 
+#' column, then we can map datasetB.DataKey to datasetA.ParticipantIdentifier 
+#' using datasetA.DataKey and datasetB.DataKey, filtering by values of 
+#' datasetA.ParticipantIdentifier that meet some criteria.
 #'
 #' @param dataset_name The name of a dataset that has the ParticipantIdentifier 
 #' variable and the mapping identifier variable (`mappingID_var`).
@@ -30,6 +35,7 @@ get_mappingID_vals_to_withdraw <- function(dataset_name, mappingID_var) {
 
 # Main --------------------------------------------------------------------
 
+# Get list of ParticipantIdentifiers of withdrawn participants
 participants_to_withdraw <- 
   arrow::open_dataset(paste0(AWS_PARQUET_DOWNLOAD_LOCATION, "/dataset_enrolledparticipants/")) %>% 
   dplyr::select(ParticipantIdentifier, CustomFields_EOPRemoveData) %>% 
@@ -67,6 +73,7 @@ contains_pid_false$participants_to_withdraw <-
     grepl("symptomlog_value", contains_pid_false$name) == TRUE ~ list(get_mappingID_vals_to_withdraw("dataset_symptomlog", "DataPointKey"))
   )
 
+# Remove data for withdrawn participants from parquet datasets based on mapping ID variables
 lapply(list.dirs(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = F), function(x) {
   if (x %in% contains_pid_false$name) {
     tmpret <- unlist(contains_pid_false$participants_to_withdraw[x == contains_pid_false$name])

--- a/remove_withdrawn_participants.R
+++ b/remove_withdrawn_participants.R
@@ -1,29 +1,75 @@
-# Datasets that contain ParticipantIdentifier column
-contains_pid <- 
-  sapply(list.dirs(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = F), function(x) {
-    grepl("ParticipantIdentifier", open_dataset(x)$metadata$org.apache.spark.sql.parquet.row.metadata)
-  }) %>% 
-  tibble::enframe()
 
-contains_pid_false <- contains_pid$name[which(contains_pid$value==FALSE)]
+# Functions ---------------------------------------------------------------
 
-sapply(contains_pid_false, function(x) {
-  open_dataset(x)
-})
+#' Get Identifier Variable Values for Withdrawn Participants
+#'
+#' This function gets the values of an identifier variable in 
+#' datasets that do not contain the ParticipantIdentifier variable, but 
+#' only for the corresponding ParticipantIdentifer values that are found 
+#' in a list containing ParticipantIdentifier values of withdrawn participants.
+#'
+#' @param dataset_name The name of a dataset that has the ParticipantIdentifier 
+#' variable and the mapping identifier variable (`mappingID_var`).
+#' @param mappingID_var The name of an identifier variable that can be 
+#' mapped to ParticipantIdentifier in the `dataset_name`'s parent dataset.
+#'
+#' @return The values of `mappingID_var` after filtering the dataset.
+#'
+#' @examples
+#' values_to_withdraw <- 
+#' get_mappingID_vals_to_withdraw("my_dataset", "DataPointKey")
+#' 
+get_mappingID_vals_to_withdraw <- function(dataset_name, mappingID_var) {
+  arrow::open_dataset(paste0(AWS_PARQUET_DOWNLOAD_LOCATION, "/", dataset_name, "/")) %>% 
+    dplyr::select(dplyr::all_of(c("ParticipantIdentifier", mappingID_var))) %>% 
+    dplyr::filter(ParticipantIdentifier %in% participants_to_withdraw) %>% 
+    dplyr::collect() %>% 
+    dplyr::pull(mappingID_var)
+}
 
-# fitbit_sleeplogs -> fitbit_sleeplogdetails: match on LogId
-# symptomlog -> symptomlog_value_symptoms, symptomlog_value_treatments: match on DataPointKey
-# healthkitv2electrocardiogram -> healthkitv2electrocardiogram_subsamples: match on HealthKitECGSampleKey
-# healthkitv2heartbeat -> healthkitv2heartbeat_subsamples: match on HealthKitHeartbeatSampleKey
-# healthkitv2workouts -> healthkitv2workouts_events: match on HealthKitWorkoutKey
 
+# Main --------------------------------------------------------------------
 
 participants_to_withdraw <- 
   arrow::open_dataset(paste0(AWS_PARQUET_DOWNLOAD_LOCATION, "/dataset_enrolledparticipants/")) %>% 
   dplyr::select(ParticipantIdentifier, CustomFields_EOPRemoveData) %>% 
   dplyr::filter(CustomFields_EOPRemoveData==1) %>%
-  dplyr::pull(ParticipantIdentifier, as_vector = TRUE) %>% 
+  dplyr::collect() %>% 
+  dplyr::pull(ParticipantIdentifier) %>% 
   unique()
+
+# Datasets that do not contain ParticipantIdentifier column
+contains_pid_false <- 
+  sapply(list.dirs(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = F), function(x) {
+    grepl("ParticipantIdentifier", open_dataset(x)$metadata$org.apache.spark.sql.parquet.row.metadata)
+  }) %>% 
+  tibble::enframe() %>% 
+  dplyr::filter(value==FALSE) %>% 
+  dplyr::pull(name)
+
+# fitbitsleeplogs -> fitbitsleeplogs_sleeplogdetails: match on LogId
+# symptomlog -> symptomlog_value_symptoms, symptomlog_value_treatments: match on DataPointKey
+# healthkitv2electrocardiogram -> healthkitv2electrocardiogram_subsamples: match on HealthKitECGSampleKey
+# healthkitv2heartbeat -> healthkitv2heartbeat_subsamples: match on HealthKitHeartbeatSampleKey
+# healthkitv2workouts -> healthkitv2workouts_events: match on HealthKitWorkoutKey
+
+fitbitsleeplogs_sleeplogdetails_to_withdraw <-
+  get_mappingID_vals_to_withdraw("dataset_fitbitsleeplogs", "LogId")
+
+symptomlog_value_symptoms_to_withdraw <-
+  get_mappingID_vals_to_withdraw("dataset_symptomlog", "DataPointKey")
+
+symptomlog_value_treatments_to_withdraw <-
+  symptomlog_value_symptoms_to_withdraw
+
+healthkitv2electrocardiogram_subsamples_to_withdraw <-
+  get_mappingID_vals_to_withdraw("dataset_healthkitv2electrocardiogram", "HealthKitECGSampleKey")
+
+healthkitv2heartbeat_subsamples_to_withdraw <-
+  get_mappingID_vals_to_withdraw("dataset_healthkitv2heartbeat", "HealthKitHeartbeatSampleKey")
+
+healthkitv2workouts_events_to_withdraw <-
+  get_mappingID_vals_to_withdraw("dataset_healthkitv2workouts", "HealthKitWorkoutKey")
 
 lapply(list.dirs(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = F), function(x) {
   if (x %in% contains_pid_false) {

--- a/remove_withdrawn_participants.R
+++ b/remove_withdrawn_participants.R
@@ -45,8 +45,18 @@ contains_pid_false <-
   }) %>% 
   tibble::enframe() %>% 
   dplyr::filter(value==FALSE) %>% 
-  dplyr::pull(name)
+  dplyr::select(name)
 
+contains_pid_false$mappingID <- 
+  dplyr::case_when(
+    grepl("fitbitsleeplogs", contains_pid_false$name) == TRUE ~ "LogId",
+    grepl("healthkitv2electrocardiogram", contains_pid_false$name) == TRUE ~ "HealthKitECGSampleKey",
+    grepl("healthkitv2heartbeat", contains_pid_false$name) == TRUE ~ "HealthKitHeartbeatSampleKey",
+    grepl("healthkitv2workout", contains_pid_false$name) == TRUE ~ "HealthKitWorkoutKey",
+    grepl("symptomlog_value", contains_pid_false$name) == TRUE ~ "DataPointKey",
+  )
+
+# Get values of mapping IDs for participants to withdraw
 fitbitsleeplogs_sleeplogdetails_to_withdraw <-
   get_mappingID_vals_to_withdraw("dataset_fitbitsleeplogs", "LogId")
 
@@ -66,7 +76,7 @@ healthkitv2workouts_events_to_withdraw <-
   get_mappingID_vals_to_withdraw("dataset_healthkitv2workouts", "HealthKitWorkoutKey")
 
 lapply(list.dirs(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = F), function(x) {
-  if (x %in% contains_pid_false) {
+  if (x %in% contains_pid_false$name) {
     # use mapping above to filter out data
   } else {
     d <-

--- a/remove_withdrawn_participants.R
+++ b/remove_withdrawn_participants.R
@@ -94,34 +94,3 @@ lapply(list.dirs(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = F), function(x) {
       basename_template = paste0("part-0000{i}.", as.character("parquet"))
     )
 })
-
-# lapply(list.dirs(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = F), function(x) {
-#   if (x %in% contains_pid_false$name) {
-#     tmpret <- unlist(contains_pid_false$participants_to_withdraw[x == contains_pid_false$name])
-#     d <- 
-#       arrow::open_dataset(x) %>%
-#       filter(!(!!(as.symbol(contains_pid_false$mappingID[x == contains_pid_false$name]))) %in% tmpret) %>% 
-#       arrow::write_dataset(path = x,
-#                            max_rows_per_file = 100000,
-#                            partitioning = "cohort",
-#                            existing_data_behavior = 'delete_matching',
-#                            basename_template = paste0("part-0000{i}.", as.character("parquet")))
-#   } else {
-#     d <-
-#       arrow::open_dataset(x) %>%
-#       filter(!ParticipantIdentifier %in% participants_to_withdraw) %>%
-#       arrow::write_dataset(path = x,
-#                            max_rows_per_file = 100000,
-#                            partitioning = "cohort",
-#                            existing_data_behavior = 'delete_matching',
-#                            basename_template = paste0("part-0000{i}.", as.character("parquet")))
-#   }
-# })
-
-# lapply(list.dirs("test_dir", recursive = F), function(x) {
-#   grepl("RA12301-00099", (open_dataset(x) %>% select(ParticipantIdentifier) %>% collect() %>% as.list()))
-# })
-# 
-# lapply(list.dirs("test_dir_new", recursive = F), function(x) {
-#   grepl("RA12301-00099", (open_dataset(x) %>% select(ParticipantIdentifier) %>% collect() %>% as.list()))
-# })

--- a/remove_withdrawn_participants.R
+++ b/remove_withdrawn_participants.R
@@ -39,7 +39,7 @@ get_mappingID_vals_to_withdraw <- function(dataset_name, mappingID_var) {
 participants_to_withdraw <- 
   arrow::open_dataset(paste0(AWS_PARQUET_DOWNLOAD_LOCATION, "/dataset_enrolledparticipants/")) %>% 
   dplyr::select(ParticipantIdentifier, CustomFields_EOPRemoveData) %>% 
-  dplyr::filter(CustomFields_EOPRemoveData==1) %>%
+  dplyr::filter(as.character(CustomFields_EOPRemoveData)=="1") %>%
   dplyr::collect() %>% 
   dplyr::pull(ParticipantIdentifier) %>% 
   unique()

--- a/remove_withdrawn_participants.R
+++ b/remove_withdrawn_participants.R
@@ -26,14 +26,18 @@ participants_to_withdraw <-
   unique()
 
 lapply(list.dirs(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = F), function(x) {
-  d <- 
-    arrow::open_dataset(x) %>% 
-    filter(!ParticipantIdentifier %in% participants_to_withdraw) %>% 
-    arrow::write_dataset(path = x, 
-                         max_rows_per_file = 100000,
-                         partitioning = "cohort", 
-                         existing_data_behavior = 'delete_matching',
-                         basename_template = paste0("part-0000{i}.", as.character("parquet")))
+  if (x %in% contains_pid_false) {
+    # use mapping above to filter out data
+  } else {
+    d <-
+      arrow::open_dataset(x) %>%
+      filter(!ParticipantIdentifier %in% participants_to_withdraw) %>%
+      arrow::write_dataset(path = x,
+                           max_rows_per_file = 100000,
+                           partitioning = "cohort",
+                           existing_data_behavior = 'delete_matching',
+                           basename_template = paste0("part-0000{i}.", as.character("parquet")))
+  }
 })
 
 # lapply(list.dirs("test_dir", recursive = F), function(x) {

--- a/remove_withdrawn_participants.R
+++ b/remove_withdrawn_participants.R
@@ -1,0 +1,25 @@
+participants_to_withdraw <- 
+  arrow::open_dataset(paste0(AWS_PARQUET_DOWNLOAD_LOCATION, "/dataset_enrolledparticipants/")) %>% 
+  dplyr::select(ParticipantIdentifier, CustomFields_EOPRemoveData) %>% 
+  dplyr::filter(CustomFields_EOPRemoveData==1) %>%
+  dplyr::pull(ParticipantIdentifier, as_vector = TRUE) %>% 
+  unique()
+
+lapply(list.dirs(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = F), function(x) {
+  d <- 
+    arrow::open_dataset(x) %>% 
+    filter(!ParticipantIdentifier %in% participants_to_withdraw) %>% 
+    arrow::write_dataset(path = x, 
+                         max_rows_per_file = 100000,
+                         partitioning = "cohort", 
+                         existing_data_behavior = 'delete_matching',
+                         basename_template = paste0("part-0000{i}.", as.character("parquet")))
+})
+
+# lapply(list.dirs("test_dir", recursive = F), function(x) {
+#   grepl("RA12301-00099", (open_dataset(x) %>% select(ParticipantIdentifier) %>% collect() %>% as.list()))
+# })
+# 
+# lapply(list.dirs("test_dir_new", recursive = F), function(x) {
+#   grepl("RA12301-00099", (open_dataset(x) %>% select(ParticipantIdentifier) %>% collect() %>% as.list()))
+# })

--- a/remove_withdrawn_participants.R
+++ b/remove_withdrawn_participants.R
@@ -1,3 +1,23 @@
+# Datasets that contain ParticipantIdentifier column
+contains_pid <- 
+  sapply(list.dirs(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = F), function(x) {
+    grepl("ParticipantIdentifier", open_dataset(x)$metadata$org.apache.spark.sql.parquet.row.metadata)
+  }) %>% 
+  tibble::enframe()
+
+contains_pid_false <- contains_pid$name[which(contains_pid$value==FALSE)]
+
+sapply(contains_pid_false, function(x) {
+  open_dataset(x)
+})
+
+# fitbit_sleeplogs -> fitbit_sleeplogdetails: match on LogId
+# symptomlog -> symptomlog_value_symptoms, symptomlog_value_treatments: match on DataPointKey
+# healthkitv2electrocardiogram -> healthkitv2electrocardiogram_subsamples: match on HealthKitECGSampleKey
+# healthkitv2heartbeat -> healthkitv2heartbeat_subsamples: match on HealthKitHeartbeatSampleKey
+# healthkitv2workouts -> healthkitv2workouts_events: match on HealthKitWorkoutKey
+
+
 participants_to_withdraw <- 
   arrow::open_dataset(paste0(AWS_PARQUET_DOWNLOAD_LOCATION, "/dataset_enrolledparticipants/")) %>% 
   dplyr::select(ParticipantIdentifier, CustomFields_EOPRemoveData) %>% 

--- a/sts_synindex_external.R
+++ b/sts_synindex_external.R
@@ -122,6 +122,10 @@ sync_cmd <- glue::glue('aws s3 sync {base_s3_uri} {AWS_PARQUET_DOWNLOAD_LOCATION
 system(sync_cmd)
 
 
+# Remove withdrawn participants -------------------------------------------
+source("~/recover-parquet-external/remove_withdrawn_participants.R")
+
+
 # Filter parquet datasets -------------------------------------------------
 source('~/recover-parquet-external/filtering.R')
 


### PR DESCRIPTION
## Major Changes

1. New step in pipeline to filter out rows of data from all parquet datasets where a withdrawn participant's `ParticipantIdentifier` (or corresponding data key) is found
2. Source the `remove_withdrawn_participants.R` script in the main pipeline script (`sts_synindex_external.R`)

