### PR TITLE
Update S3 path in file provenance

### DIFF
--- a/scripts/main/sts_synindex_external.R
+++ b/scripts/main/sts_synindex_external.R
@@ -91,6 +91,11 @@ replace_equal_with_underscore <- function(directory_path) {
 synapser::synLogin(authToken = Sys.getenv('SYNAPSE_AUTH_TOKEN'))
 config::get(config = "staging") %>% list2env(envir = .GlobalEnv)
 
+unlink(x = c(AWS_PARQUET_DOWNLOAD_LOCATION,
+             AWS_ARCHIVE_DOWNLOAD_LOCATION,
+             PARQUET_FINAL_LOCATION), 
+       recursive = TRUE, 
+       force = TRUE)
 
 # Get STS credentials for input data bucket -------------------------------
 token <- 

--- a/scripts/main/sts_synindex_external.R
+++ b/scripts/main/sts_synindex_external.R
@@ -218,7 +218,7 @@ latest_commit_this_file <- paste0(latest_commit$html_url %>% stringr::str_replac
 
 act <- synapser::Activity(name = "Indexing",
                           description = "Indexing external parquet datasets",
-                          used = paste0("s3://", latest_archive), 
+                          used = paste0("https://s3.amazonaws.com/", latest_archive), 
                           executed = latest_commit_this_file)
 
 if(nrow(synapse_manifest_to_upload) > 0){


### PR DESCRIPTION
## Major Changes

1. Use https format for S3 path for file provenance

## Minor Changes

1. Delete directories that were created on previous pipeline runs to make sure that each pipeline run starts without old data
