### PR TITLE
Trim whitespace from column values before using in subsequent steps

### DIFF
--- a/scripts/filtering/filtering.R
+++ b/scripts/filtering/filtering.R
@@ -71,7 +71,10 @@ unlink(PARQUET_FILTERED_LOCATION, recursive = T, force = T)
 
 synLogin()
 
-pii_to_drop <- synGet(PII_COLS_TO_DROP)$path %>% read.csv()
+pii_to_drop <- 
+  synGet(PII_COLS_TO_DROP)$path %>% 
+  read.csv() %>% 
+  dplyr::mutate(column_to_be_dropped = trimws(column_to_be_dropped))
 
 datasets_to_filter <- pii_to_drop$dataset %>% unique()
 cols_to_drop <- lapply(datasets_to_filter, function(x) {


### PR DESCRIPTION
## Major Changes

1. Trim whitespace from column values before using in subsequent steps